### PR TITLE
1 서버별 파티모집 분리작업

### DIFF
--- a/.cursor/rules/discord-bot-rules.mdc
+++ b/.cursor/rules/discord-bot-rules.mdc
@@ -1,6 +1,11 @@
 ---
 description: 
 globs: 
+alwaysApply: false
+---
+---
+description: 
+globs: 
 alwaysApply: true
 ---
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea*
 __pycache__/
 */__pycache__/
+*log*


### PR DESCRIPTION
이  pull request에는 'views/recruption_card_views.py' 파일에 대한 몇 가지 중요한 변경 사항과 '.cursor/rules/discord-bot-rules.mdc' 파일에 대한 약간의 업데이트가 포함됩니다. 가장 중요한 변경 사항은 채널을 강제로 정리하는 새로운 방법을 추가하고 임시 메시지를 제거하는 것입니다.

### 주요 변경 사항:

#### 새로운 메서드 추가:
* 특정 채널에서 완료된 모집 메시지를 강제로 삭제하는 'force_cleanup_channel' 메서드가 추가되었습니다. 이 메서드에는 견고한 작동을 보장하기 위해 상세한 로깅과 오류 처리가 포함되어 있습니다.

#### 코드 정리:
* 채용 콘텐츠 저장 과정을 간소화하기 위해 '온_서브미션' 방식으로 임시 메시지 알림과 삭제를 제거했습니다.

### 사소한 변경 사항:

* '.cursor/rules/discord-bot-rules.mdc' 파일을 업데이트하여 '항상 적용'을 '거짓'으로 설정한 새 규칙을 포함시켰습니다.